### PR TITLE
Ensure requestData.params always is an object

### DIFF
--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -25,7 +25,6 @@ var SpotifyWebApi = (function() {
   var _checkParamsAndPerformRequest = function(requestData, options, callback) {
     var opt = {};
     var cb = null;
-    requestData.params = requestData.params || {};
 
     if (typeof options === 'object') {
       opt = options;
@@ -33,7 +32,7 @@ var SpotifyWebApi = (function() {
     } else if (typeof options === 'function') {
       cb = options;
     }
-    _extend(requestData.params, opt);
+    _extend(requestData, { params: opt });
     return _performRequest(requestData, cb);
   };
 


### PR DESCRIPTION
Otherwise, it won't be extended correctly with custom query parameters.

Below, if `requestData.params` doesn't exists, it won't be extended in `_extend`.

``` javascript
_extend(requestData.params, opt);
return _performRequest(requestData, cb);
```
