### PR TITLE
Send null instead of stringifying undefined

### DIFF
--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -115,7 +115,7 @@ var SpotifyWebApi = (function() {
       if (type === 'GET') {
         req.send(null);
       } else {
-        req.send(JSON.stringify(requestData.postData));
+        req.send(requestData.postData ? JSON.stringify(requestData.postData) : null);
       }
     };
 


### PR DESCRIPTION
IE11 was complaining when making a non-GET request with empty body, which was being serialized as `undefined`. This change fixes it to send `null` instead.