### PR TITLE
Send track URIs in body of request for addTracksToPlaylist

### DIFF
--- a/__test__/spotify-web-api.spec.js
+++ b/__test__/spotify-web-api.spec.js
@@ -575,7 +575,10 @@ var Q = require('q');
         );
         expect(callback.calledWith(null, '')).toBeTruthy();
         expect(that.requests.length).toBe(1);
-        expect(that.requests[0].url).toBe('https://api.spotify.com/v1/users/jmperezperez/playlists/7Kud0O2IdWLbEGgvBkW9di/tracks?uris=spotify%3Atrack%3A2Oehrcv4Kov0SuIgWyQY9e');
+        expect(that.requests[0].url).toBe('https://api.spotify.com/v1/users/jmperezperez/playlists/7Kud0O2IdWLbEGgvBkW9di/tracks');
+        expect(that.requests[0].requestBody).toBe(JSON.stringify({
+          uris: ['spotify:track:2Oehrcv4Kov0SuIgWyQY9e']
+        }));
       });
 
       it('should add tracks to a playlist, specifying position', function() {
@@ -589,7 +592,10 @@ var Q = require('q');
         );
         expect(callback.calledWith(null, '')).toBeTruthy();
         expect(that.requests.length).toBe(1);
-        expect(that.requests[0].url).toBe('https://api.spotify.com/v1/users/jmperezperez/playlists/7Kud0O2IdWLbEGgvBkW9di/tracks?uris=spotify%3Atrack%3A2Oehrcv4Kov0SuIgWyQY9e&position=0');
+        expect(that.requests[0].url).toBe('https://api.spotify.com/v1/users/jmperezperez/playlists/7Kud0O2IdWLbEGgvBkW9di/tracks?position=0');
+        expect(that.requests[0].requestBody).toBe(JSON.stringify({
+          uris: ['spotify:track:2Oehrcv4Kov0SuIgWyQY9e']
+        }));
       });
 
       it('should remove tracks from a playlist', function() {

--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -129,7 +129,7 @@ var SpotifyWebApi = (function() {
     }
   };
 
-  var _checkParamsAndPerformRequest = function(requestData, options, callback) {
+  var _checkParamsAndPerformRequest = function(requestData, options, callback, optionsAlwaysExtendParams) {
     var opt = {};
     var cb = null;
 
@@ -142,7 +142,7 @@ var SpotifyWebApi = (function() {
 
     // options extend postData, if any. Otherwise they extend parameters sent in the url
     var type = requestData.type || 'GET';
-    if (type !== 'GET' && requestData.postData) {
+    if (type !== 'GET' && requestData.postData && !optionsAlwaysExtendParams) {
       requestData.postData = _extend(requestData.postData, opt);
     } else {
       requestData.params = _extend(requestData.params, opt);
@@ -771,11 +771,11 @@ var SpotifyWebApi = (function() {
     var requestData = {
       url: _baseUri + '/users/' + encodeURIComponent(userId) + '/playlists/' + playlistId + '/tracks',
       type: 'POST',
-      params: {
+      postData: {
         uris: uris
       }
     };
-    return _checkParamsAndPerformRequest(requestData, options, callback);
+    return _checkParamsAndPerformRequest(requestData, options, callback, true);
   };
 
   /**


### PR DESCRIPTION
Fixes the 'URI too long' error.