### PR TITLE
Changed skipToNext and skipToPrevious from PUT to POST

### DIFF
--- a/__test__/spotify-web-api.spec.js
+++ b/__test__/spotify-web-api.spec.js
@@ -1160,7 +1160,7 @@ describe('Basic tests', function() {
       var api = new SpotifyWebApi();
       api.skipToNext({ device_id: 'my_device_id' }, callback);
       that.requests[0].respond(204);
-      expect(that.requests[0].method).toBe('PUT');
+      expect(that.requests[0].method).toBe('POST');
       expect(callback.calledWith(null, '')).toBeTruthy();
       expect(that.requests.length).toBe(1);
       expect(that.requests[0].url).toBe('https://api.spotify.com/v1/me/player/next?device_id=my_device_id');
@@ -1171,7 +1171,7 @@ describe('Basic tests', function() {
       var api = new SpotifyWebApi();
       api.skipToPrevious({ device_id: 'my_device_id' }, callback);
       that.requests[0].respond(204);
-      expect(that.requests[0].method).toBe('PUT');
+      expect(that.requests[0].method).toBe('POST');
       expect(callback.calledWith(null, '')).toBeTruthy();
       expect(that.requests.length).toBe(1);
       expect(that.requests[0].url).toBe('https://api.spotify.com/v1/me/player/previous?device_id=my_device_id');

--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -1544,7 +1544,7 @@ var SpotifyWebApi = (function() {
   Constr.prototype.skipToNext = function(options, callback) {
     var params = 'device_id' in options ? {device_id: options.device_id} : null;
     var requestData = {
-      type: 'PUT',
+      type: 'POST',
       url: _baseUri + '/me/player/next',
       params: params
     };
@@ -1566,7 +1566,7 @@ var SpotifyWebApi = (function() {
   Constr.prototype.skipToPrevious = function(options, callback) {
     var params = 'device_id' in options ? {device_id: options.device_id} : null;
     var requestData = {
-      type: 'PUT',
+      type: 'POST',
       url: _baseUri + '/me/player/previous',
       params: params
     };


### PR DESCRIPTION
Next and Previous api uses POST requests, and returns a 405 on PUT.

https://developer.spotify.com/web-api/skip-users-playback-to-next-track/