### PR TITLE
Add support for position_ms in play command - Fixes #104

### DIFF
--- a/__test__/spotify-web-api.spec.js
+++ b/__test__/spotify-web-api.spec.js
@@ -1149,7 +1149,7 @@ describe('Basic tests', function() {
     it('should play on a certain device', function() {
       var callback = sinon.spy();
       var api = new SpotifyWebApi();
-      api.play({ device_id: 'my_device_id', context_uri: 'spotify:album:xxx' }, callback);
+      api.play({ device_id: 'my_device_id', context_uri: 'spotify:album:xxx', position_ms: 2000 }, callback);
       that.requests[0].respond(204);
       expect(that.requests[0].method).toBe('PUT');
       expect(callback.calledWith(null, '')).toBeTruthy();
@@ -1157,7 +1157,8 @@ describe('Basic tests', function() {
       expect(that.requests[0].url).toBe('https://api.spotify.com/v1/me/player/play?device_id=my_device_id');
       expect(that.requests[0].requestBody).toBe(
         JSON.stringify({
-          context_uri: 'spotify:album:xxx'
+          context_uri: 'spotify:album:xxx',
+          position_ms: 2000
         })
       );
     });

--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -1526,7 +1526,7 @@ var SpotifyWebApi = (function() {
     options = options || {};
     var params = 'device_id' in options ? {device_id: options.device_id} : null;
     var postData = {};
-    ['context_uri', 'uris', 'offset'].forEach(function(field) {
+    ['context_uri', 'uris', 'offset', 'position_ms'].forEach(function(field) {
       if (field in options) {
         postData[field] = options[field];
       }


### PR DESCRIPTION
Adds support for the `position_ms` field, which was included recently.

Read https://github.com/spotify/web-api/issues/596#issuecomment-414275276 for more information.