### PR TITLE
Verify options exist before checking a value for device_id

### DIFF
--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -1593,7 +1593,7 @@ var SpotifyWebApi = (function() {
     var params = {
       position_ms: position_ms
     };
-    if ('device_id' in options) {
+    if (options && 'device_id' in options) {
       params.device_id = options.device_id;
     }
     var requestData = {


### PR DESCRIPTION
Currently we have to do something like `seek(0, {})` which doesn't feel right. This should verify that options exist before we try to look at the values of options