### PR TITLE
Fix play api call

### DIFF
--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -1506,7 +1506,8 @@ var SpotifyWebApi = (function() {
       type: 'PUT',
       url: _baseUri + '/me/player/play',
       params: params,
-      postData: postData
+      postData: postData,
+      contentType: 'application/json'
     };
 
     // need to clear options so it doesn't add all of them to the query params


### PR DESCRIPTION
The /me/player/play endpoint expects a contentType of 'application/json'. If contentType isn't specified the response has a chance of crashing the web app