### PR TITLE
Add support for "Get the User's Queue" API endpoint

### DIFF
--- a/__test__/fixtures.js
+++ b/__test__/fixtures.js
@@ -64,5 +64,6 @@ module.exports = {
   shows: loadFixture('shows'),
   show_episodes: loadFixture('show_episodes'),
   episode: loadFixture('episode'),
-  episodes: loadFixture('episodes')
+  episodes: loadFixture('episodes'),
+  get_queue: loadFixture('get_queue')
 };

--- a/__test__/fixtures/get_queue.json
+++ b/__test__/fixtures/get_queue.json
@@ -1,0 +1,1980 @@
+{
+  "currently_playing": {
+    "album": {
+      "album_type": "compilation",
+      "total_tracks": 9,
+      "available_markets": ["CA", "BR", "IT"],
+      "external_urls": {
+        "spotify": "string"
+      },
+      "href": "string",
+      "id": "2up3OPMp9Tb4dAKM2erWXQ",
+      "images": [
+        {
+          "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+          "height": 300,
+          "width": 300
+        }
+      ],
+      "name": "string",
+      "release_date": "1981-12",
+      "release_date_precision": "year",
+      "restrictions": {
+        "reason": "market"
+      },
+      "type": "album",
+      "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+      "album_group": "compilation",
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "string"
+          },
+          "href": "string",
+          "id": "string",
+          "name": "string",
+          "type": "artist",
+          "uri": "string"
+        }
+      ]
+    },
+    "artists": [
+      {
+        "external_urls": {
+          "spotify": "string"
+        },
+        "followers": {
+          "href": "string",
+          "total": 0
+        },
+        "genres": ["Prog rock", "Grunge"],
+        "href": "string",
+        "id": "string",
+        "images": [
+          {
+            "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+            "height": 300,
+            "width": 300
+          }
+        ],
+        "name": "string",
+        "popularity": 0,
+        "type": "artist",
+        "uri": "string"
+      }
+    ],
+    "available_markets": ["string"],
+    "disc_number": 0,
+    "duration_ms": 0,
+    "explicit": true,
+    "external_ids": {
+      "isrc": "string",
+      "ean": "string",
+      "upc": "string"
+    },
+    "external_urls": {
+      "spotify": "string"
+    },
+    "href": "string",
+    "id": "string",
+    "is_playable": true,
+    "linked_from": {
+      "album": {
+        "album_type": "compilation",
+        "total_tracks": 9,
+        "available_markets": ["CA", "BR", "IT"],
+        "external_urls": {
+          "spotify": "string"
+        },
+        "href": "string",
+        "id": "2up3OPMp9Tb4dAKM2erWXQ",
+        "images": [
+          {
+            "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+            "height": 300,
+            "width": 300
+          }
+        ],
+        "name": "string",
+        "release_date": "1981-12",
+        "release_date_precision": "year",
+        "restrictions": {
+          "reason": "market"
+        },
+        "type": "album",
+        "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+        "album_group": "compilation",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "string"
+            },
+            "href": "string",
+            "id": "string",
+            "name": "string",
+            "type": "artist",
+            "uri": "string"
+          }
+        ]
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "string"
+          },
+          "followers": {
+            "href": "string",
+            "total": 0
+          },
+          "genres": ["Prog rock", "Grunge"],
+          "href": "string",
+          "id": "string",
+          "images": [
+            {
+              "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+              "height": 300,
+              "width": 300
+            }
+          ],
+          "name": "string",
+          "popularity": 0,
+          "type": "artist",
+          "uri": "string"
+        }
+      ],
+      "available_markets": ["string"],
+      "disc_number": 0,
+      "duration_ms": 0,
+      "explicit": true,
+      "external_ids": {
+        "isrc": "string",
+        "ean": "string",
+        "upc": "string"
+      },
+      "external_urls": {
+        "spotify": "string"
+      },
+      "href": "string",
+      "id": "string",
+      "is_playable": true,
+      "linked_from": {
+        "album": {
+          "album_type": "compilation",
+          "total_tracks": 9,
+          "available_markets": ["CA", "BR", "IT"],
+          "external_urls": {
+            "spotify": "string"
+          },
+          "href": "string",
+          "id": "2up3OPMp9Tb4dAKM2erWXQ",
+          "images": [
+            {
+              "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+              "height": 300,
+              "width": 300
+            }
+          ],
+          "name": "string",
+          "release_date": "1981-12",
+          "release_date_precision": "year",
+          "restrictions": {
+            "reason": "market"
+          },
+          "type": "album",
+          "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+          "album_group": "compilation",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "string"
+              },
+              "href": "string",
+              "id": "string",
+              "name": "string",
+              "type": "artist",
+              "uri": "string"
+            }
+          ]
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "string"
+            },
+            "followers": {
+              "href": "string",
+              "total": 0
+            },
+            "genres": ["Prog rock", "Grunge"],
+            "href": "string",
+            "id": "string",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                "height": 300,
+                "width": 300
+              }
+            ],
+            "name": "string",
+            "popularity": 0,
+            "type": "artist",
+            "uri": "string"
+          }
+        ],
+        "available_markets": ["string"],
+        "disc_number": 0,
+        "duration_ms": 0,
+        "explicit": true,
+        "external_ids": {
+          "isrc": "string",
+          "ean": "string",
+          "upc": "string"
+        },
+        "external_urls": {
+          "spotify": "string"
+        },
+        "href": "string",
+        "id": "string",
+        "is_playable": true,
+        "linked_from": {
+          "album": {
+            "album_type": "compilation",
+            "total_tracks": 9,
+            "available_markets": ["CA", "BR", "IT"],
+            "external_urls": {
+              "spotify": "string"
+            },
+            "href": "string",
+            "id": "2up3OPMp9Tb4dAKM2erWXQ",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                "height": 300,
+                "width": 300
+              }
+            ],
+            "name": "string",
+            "release_date": "1981-12",
+            "release_date_precision": "year",
+            "restrictions": {
+              "reason": "market"
+            },
+            "type": "album",
+            "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+            "album_group": "compilation",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "string"
+                },
+                "href": "string",
+                "id": "string",
+                "name": "string",
+                "type": "artist",
+                "uri": "string"
+              }
+            ]
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "string"
+              },
+              "followers": {
+                "href": "string",
+                "total": 0
+              },
+              "genres": ["Prog rock", "Grunge"],
+              "href": "string",
+              "id": "string",
+              "images": [
+                {
+                  "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                  "height": 300,
+                  "width": 300
+                }
+              ],
+              "name": "string",
+              "popularity": 0,
+              "type": "artist",
+              "uri": "string"
+            }
+          ],
+          "available_markets": ["string"],
+          "disc_number": 0,
+          "duration_ms": 0,
+          "explicit": true,
+          "external_ids": {
+            "isrc": "string",
+            "ean": "string",
+            "upc": "string"
+          },
+          "external_urls": {
+            "spotify": "string"
+          },
+          "href": "string",
+          "id": "string",
+          "is_playable": true,
+          "linked_from": {
+            "album": {
+              "album_type": "compilation",
+              "total_tracks": 9,
+              "available_markets": ["CA", "BR", "IT"],
+              "external_urls": {
+                "spotify": "string"
+              },
+              "href": "string",
+              "id": "2up3OPMp9Tb4dAKM2erWXQ",
+              "images": [
+                {
+                  "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                  "height": 300,
+                  "width": 300
+                }
+              ],
+              "name": "string",
+              "release_date": "1981-12",
+              "release_date_precision": "year",
+              "restrictions": {
+                "reason": "market"
+              },
+              "type": "album",
+              "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+              "album_group": "compilation",
+              "artists": [
+                {
+                  "external_urls": {
+                    "spotify": "string"
+                  },
+                  "href": "string",
+                  "id": "string",
+                  "name": "string",
+                  "type": "artist",
+                  "uri": "string"
+                }
+              ]
+            },
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "string"
+                },
+                "followers": {
+                  "href": "string",
+                  "total": 0
+                },
+                "genres": ["Prog rock", "Grunge"],
+                "href": "string",
+                "id": "string",
+                "images": [
+                  {
+                    "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                    "height": 300,
+                    "width": 300
+                  }
+                ],
+                "name": "string",
+                "popularity": 0,
+                "type": "artist",
+                "uri": "string"
+              }
+            ],
+            "available_markets": ["string"],
+            "disc_number": 0,
+            "duration_ms": 0,
+            "explicit": true,
+            "external_ids": {
+              "isrc": "string",
+              "ean": "string",
+              "upc": "string"
+            },
+            "external_urls": {
+              "spotify": "string"
+            },
+            "href": "string",
+            "id": "string",
+            "is_playable": true,
+            "linked_from": {
+              "album": {
+                "album_type": "compilation",
+                "total_tracks": 9,
+                "available_markets": ["CA", "BR", "IT"],
+                "external_urls": {
+                  "spotify": "string"
+                },
+                "href": "string",
+                "id": "2up3OPMp9Tb4dAKM2erWXQ",
+                "images": [
+                  {
+                    "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                    "height": 300,
+                    "width": 300
+                  }
+                ],
+                "name": "string",
+                "release_date": "1981-12",
+                "release_date_precision": "year",
+                "restrictions": {
+                  "reason": "market"
+                },
+                "type": "album",
+                "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+                "album_group": "compilation",
+                "artists": [
+                  {
+                    "external_urls": {
+                      "spotify": "string"
+                    },
+                    "href": "string",
+                    "id": "string",
+                    "name": "string",
+                    "type": "artist",
+                    "uri": "string"
+                  }
+                ]
+              },
+              "artists": [
+                {
+                  "external_urls": {
+                    "spotify": "string"
+                  },
+                  "followers": {
+                    "href": "string",
+                    "total": 0
+                  },
+                  "genres": ["Prog rock", "Grunge"],
+                  "href": "string",
+                  "id": "string",
+                  "images": [
+                    {
+                      "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                      "height": 300,
+                      "width": 300
+                    }
+                  ],
+                  "name": "string",
+                  "popularity": 0,
+                  "type": "artist",
+                  "uri": "string"
+                }
+              ],
+              "available_markets": ["string"],
+              "disc_number": 0,
+              "duration_ms": 0,
+              "explicit": true,
+              "external_ids": {
+                "isrc": "string",
+                "ean": "string",
+                "upc": "string"
+              },
+              "external_urls": {
+                "spotify": "string"
+              },
+              "href": "string",
+              "id": "string",
+              "is_playable": true,
+              "linked_from": {
+                "album": {
+                  "album_type": "compilation",
+                  "total_tracks": 9,
+                  "available_markets": ["CA", "BR", "IT"],
+                  "external_urls": {
+                    "spotify": "string"
+                  },
+                  "href": "string",
+                  "id": "2up3OPMp9Tb4dAKM2erWXQ",
+                  "images": [
+                    {
+                      "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                      "height": 300,
+                      "width": 300
+                    }
+                  ],
+                  "name": "string",
+                  "release_date": "1981-12",
+                  "release_date_precision": "year",
+                  "restrictions": {
+                    "reason": "market"
+                  },
+                  "type": "album",
+                  "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+                  "album_group": "compilation",
+                  "artists": [
+                    {
+                      "external_urls": {
+                        "spotify": "string"
+                      },
+                      "href": "string",
+                      "id": "string",
+                      "name": "string",
+                      "type": "artist",
+                      "uri": "string"
+                    }
+                  ]
+                },
+                "artists": [
+                  {
+                    "external_urls": {
+                      "spotify": "string"
+                    },
+                    "followers": {
+                      "href": "string",
+                      "total": 0
+                    },
+                    "genres": ["Prog rock", "Grunge"],
+                    "href": "string",
+                    "id": "string",
+                    "images": [
+                      {
+                        "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                        "height": 300,
+                        "width": 300
+                      }
+                    ],
+                    "name": "string",
+                    "popularity": 0,
+                    "type": "artist",
+                    "uri": "string"
+                  }
+                ],
+                "available_markets": ["string"],
+                "disc_number": 0,
+                "duration_ms": 0,
+                "explicit": true,
+                "external_ids": {
+                  "isrc": "string",
+                  "ean": "string",
+                  "upc": "string"
+                },
+                "external_urls": {
+                  "spotify": "string"
+                },
+                "href": "string",
+                "id": "string",
+                "is_playable": true,
+                "linked_from": {
+                  "album": {
+                    "album_type": "compilation",
+                    "total_tracks": 9,
+                    "available_markets": ["CA", "BR", "IT"],
+                    "external_urls": {
+                      "spotify": "string"
+                    },
+                    "href": "string",
+                    "id": "2up3OPMp9Tb4dAKM2erWXQ",
+                    "images": [
+                      {
+                        "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                        "height": 300,
+                        "width": 300
+                      }
+                    ],
+                    "name": "string",
+                    "release_date": "1981-12",
+                    "release_date_precision": "year",
+                    "restrictions": {
+                      "reason": "market"
+                    },
+                    "type": "album",
+                    "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+                    "album_group": "compilation",
+                    "artists": [
+                      {
+                        "external_urls": {
+                          "spotify": "string"
+                        },
+                        "href": "string",
+                        "id": "string",
+                        "name": "string",
+                        "type": "artist",
+                        "uri": "string"
+                      }
+                    ]
+                  },
+                  "artists": [
+                    {
+                      "external_urls": {
+                        "spotify": "string"
+                      },
+                      "followers": {
+                        "href": "string",
+                        "total": 0
+                      },
+                      "genres": ["Prog rock", "Grunge"],
+                      "href": "string",
+                      "id": "string",
+                      "images": [
+                        {
+                          "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                          "height": 300,
+                          "width": 300
+                        }
+                      ],
+                      "name": "string",
+                      "popularity": 0,
+                      "type": "artist",
+                      "uri": "string"
+                    }
+                  ],
+                  "available_markets": ["string"],
+                  "disc_number": 0,
+                  "duration_ms": 0,
+                  "explicit": true,
+                  "external_ids": {
+                    "isrc": "string",
+                    "ean": "string",
+                    "upc": "string"
+                  },
+                  "external_urls": {
+                    "spotify": "string"
+                  },
+                  "href": "string",
+                  "id": "string",
+                  "is_playable": true,
+                  "linked_from": {
+                    "album": {
+                      "album_type": "compilation",
+                      "total_tracks": 9,
+                      "available_markets": ["CA", "BR", "IT"],
+                      "external_urls": {
+                        "spotify": "string"
+                      },
+                      "href": "string",
+                      "id": "2up3OPMp9Tb4dAKM2erWXQ",
+                      "images": [
+                        {
+                          "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                          "height": 300,
+                          "width": 300
+                        }
+                      ],
+                      "name": "string",
+                      "release_date": "1981-12",
+                      "release_date_precision": "year",
+                      "restrictions": {
+                        "reason": "market"
+                      },
+                      "type": "album",
+                      "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+                      "album_group": "compilation",
+                      "artists": [
+                        {
+                          "external_urls": {
+                            "spotify": "string"
+                          },
+                          "href": "string",
+                          "id": "string",
+                          "name": "string",
+                          "type": "artist",
+                          "uri": "string"
+                        }
+                      ]
+                    },
+                    "artists": [
+                      {
+                        "external_urls": {
+                          "spotify": "string"
+                        },
+                        "followers": {
+                          "href": "string",
+                          "total": 0
+                        },
+                        "genres": ["Prog rock", "Grunge"],
+                        "href": "string",
+                        "id": "string",
+                        "images": [
+                          {
+                            "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                            "height": 300,
+                            "width": 300
+                          }
+                        ],
+                        "name": "string",
+                        "popularity": 0,
+                        "type": "artist",
+                        "uri": "string"
+                      }
+                    ],
+                    "available_markets": ["string"],
+                    "disc_number": 0,
+                    "duration_ms": 0,
+                    "explicit": true,
+                    "external_ids": {
+                      "isrc": "string",
+                      "ean": "string",
+                      "upc": "string"
+                    },
+                    "external_urls": {
+                      "spotify": "string"
+                    },
+                    "href": "string",
+                    "id": "string",
+                    "is_playable": true,
+                    "linked_from": {
+                      "album": {
+                        "album_type": "compilation",
+                        "total_tracks": 9,
+                        "available_markets": ["CA", "BR", "IT"],
+                        "external_urls": {
+                          "spotify": "string"
+                        },
+                        "href": "string",
+                        "id": "2up3OPMp9Tb4dAKM2erWXQ",
+                        "images": [
+                          {
+                            "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                            "height": 300,
+                            "width": 300
+                          }
+                        ],
+                        "name": "string",
+                        "release_date": "1981-12",
+                        "release_date_precision": "year",
+                        "restrictions": {
+                          "reason": "market"
+                        },
+                        "type": "album",
+                        "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+                        "album_group": "compilation",
+                        "artists": [
+                          {
+                            "external_urls": {},
+                            "href": "string",
+                            "id": "string",
+                            "name": "string",
+                            "type": "artist",
+                            "uri": "string"
+                          }
+                        ]
+                      },
+                      "artists": [
+                        {
+                          "external_urls": {
+                            "spotify": "string"
+                          },
+                          "followers": {
+                            "href": "string",
+                            "total": 0
+                          },
+                          "genres": ["Prog rock", "Grunge"],
+                          "href": "string",
+                          "id": "string",
+                          "images": [{}],
+                          "name": "string",
+                          "popularity": 0,
+                          "type": "artist",
+                          "uri": "string"
+                        }
+                      ],
+                      "available_markets": ["string"],
+                      "disc_number": 0,
+                      "duration_ms": 0,
+                      "explicit": true,
+                      "external_ids": {
+                        "isrc": "string",
+                        "ean": "string",
+                        "upc": "string"
+                      },
+                      "external_urls": {
+                        "spotify": "string"
+                      },
+                      "href": "string",
+                      "id": "string",
+                      "is_playable": true,
+                      "linked_from": {
+                        "album": {
+                          "album_type": "compilation",
+                          "total_tracks": 9,
+                          "available_markets": ["CA", "BR", "IT"],
+                          "external_urls": {
+                            "spotify": "string"
+                          },
+                          "href": "string",
+                          "id": "2up3OPMp9Tb4dAKM2erWXQ",
+                          "images": [{}],
+                          "name": "string",
+                          "release_date": "1981-12",
+                          "release_date_precision": "year",
+                          "restrictions": {
+                            "reason": "market"
+                          },
+                          "type": "album",
+                          "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+                          "album_group": "compilation",
+                          "artists": [{}]
+                        },
+                        "artists": [
+                          {
+                            "external_urls": {},
+                            "followers": {},
+                            "genres": ["Prog rock", "Grunge"],
+                            "href": "string",
+                            "id": "string",
+                            "images": [{}],
+                            "name": "string",
+                            "popularity": 0,
+                            "type": "artist",
+                            "uri": "string"
+                          }
+                        ],
+                        "available_markets": ["string"],
+                        "disc_number": 0,
+                        "duration_ms": 0,
+                        "explicit": true,
+                        "external_ids": {
+                          "isrc": "string",
+                          "ean": "string",
+                          "upc": "string"
+                        },
+                        "external_urls": {
+                          "spotify": "string"
+                        },
+                        "href": "string",
+                        "id": "string",
+                        "is_playable": true,
+                        "linked_from": {
+                          "album": {
+                            "album_type": "compilation",
+                            "total_tracks": 9,
+                            "available_markets": ["CA", "BR", "IT"],
+                            "external_urls": {},
+                            "href": "string",
+                            "id": "2up3OPMp9Tb4dAKM2erWXQ",
+                            "images": [{}],
+                            "name": "string",
+                            "release_date": "1981-12",
+                            "release_date_precision": "year",
+                            "restrictions": {},
+                            "type": "album",
+                            "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+                            "album_group": "compilation",
+                            "artists": [{}]
+                          },
+                          "artists": [
+                            {
+                              "genres": [],
+                              "images": []
+                            }
+                          ],
+                          "available_markets": ["string"],
+                          "disc_number": 0,
+                          "duration_ms": 0,
+                          "explicit": true,
+                          "external_ids": {
+                            "isrc": "string",
+                            "ean": "string",
+                            "upc": "string"
+                          },
+                          "external_urls": {
+                            "spotify": "string"
+                          },
+                          "href": "string",
+                          "id": "string",
+                          "is_playable": true,
+                          "linked_from": {
+                            "album": {
+                              "available_markets": [],
+                              "images": [],
+                              "artists": []
+                            },
+                            "artists": [{}],
+                            "available_markets": [null],
+                            "disc_number": 0,
+                            "duration_ms": 0,
+                            "explicit": true,
+                            "external_ids": {},
+                            "external_urls": {},
+                            "href": "string",
+                            "id": "string",
+                            "is_playable": true,
+                            "linked_from": {
+                              "artists": [],
+                              "available_markets": []
+                            },
+                            "restrictions": {},
+                            "name": "string",
+                            "popularity": 0,
+                            "preview_url": "string",
+                            "track_number": 0,
+                            "type": "string",
+                            "uri": "string",
+                            "is_local": true
+                          },
+                          "restrictions": {
+                            "reason": "string"
+                          },
+                          "name": "string",
+                          "popularity": 0,
+                          "preview_url": "string",
+                          "track_number": 0,
+                          "type": "string",
+                          "uri": "string",
+                          "is_local": true
+                        },
+                        "restrictions": {
+                          "reason": "string"
+                        },
+                        "name": "string",
+                        "popularity": 0,
+                        "preview_url": "string",
+                        "track_number": 0,
+                        "type": "string",
+                        "uri": "string",
+                        "is_local": true
+                      },
+                      "restrictions": {
+                        "reason": "string"
+                      },
+                      "name": "string",
+                      "popularity": 0,
+                      "preview_url": "string",
+                      "track_number": 0,
+                      "type": "string",
+                      "uri": "string",
+                      "is_local": true
+                    },
+                    "restrictions": {
+                      "reason": "string"
+                    },
+                    "name": "string",
+                    "popularity": 0,
+                    "preview_url": "string",
+                    "track_number": 0,
+                    "type": "string",
+                    "uri": "string",
+                    "is_local": true
+                  },
+                  "restrictions": {
+                    "reason": "string"
+                  },
+                  "name": "string",
+                  "popularity": 0,
+                  "preview_url": "string",
+                  "track_number": 0,
+                  "type": "string",
+                  "uri": "string",
+                  "is_local": true
+                },
+                "restrictions": {
+                  "reason": "string"
+                },
+                "name": "string",
+                "popularity": 0,
+                "preview_url": "string",
+                "track_number": 0,
+                "type": "string",
+                "uri": "string",
+                "is_local": true
+              },
+              "restrictions": {
+                "reason": "string"
+              },
+              "name": "string",
+              "popularity": 0,
+              "preview_url": "string",
+              "track_number": 0,
+              "type": "string",
+              "uri": "string",
+              "is_local": true
+            },
+            "restrictions": {
+              "reason": "string"
+            },
+            "name": "string",
+            "popularity": 0,
+            "preview_url": "string",
+            "track_number": 0,
+            "type": "string",
+            "uri": "string",
+            "is_local": true
+          },
+          "restrictions": {
+            "reason": "string"
+          },
+          "name": "string",
+          "popularity": 0,
+          "preview_url": "string",
+          "track_number": 0,
+          "type": "string",
+          "uri": "string",
+          "is_local": true
+        },
+        "restrictions": {
+          "reason": "string"
+        },
+        "name": "string",
+        "popularity": 0,
+        "preview_url": "string",
+        "track_number": 0,
+        "type": "string",
+        "uri": "string",
+        "is_local": true
+      },
+      "restrictions": {
+        "reason": "string"
+      },
+      "name": "string",
+      "popularity": 0,
+      "preview_url": "string",
+      "track_number": 0,
+      "type": "string",
+      "uri": "string",
+      "is_local": true
+    },
+    "restrictions": {
+      "reason": "string"
+    },
+    "name": "string",
+    "popularity": 0,
+    "preview_url": "string",
+    "track_number": 0,
+    "type": "string",
+    "uri": "string",
+    "is_local": true
+  },
+  "queue": [
+    {
+      "album": {
+        "album_type": "compilation",
+        "total_tracks": 9,
+        "available_markets": ["CA", "BR", "IT"],
+        "external_urls": {
+          "spotify": "string"
+        },
+        "href": "string",
+        "id": "2up3OPMp9Tb4dAKM2erWXQ",
+        "images": [
+          {
+            "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+            "height": 300,
+            "width": 300
+          }
+        ],
+        "name": "string",
+        "release_date": "1981-12",
+        "release_date_precision": "year",
+        "restrictions": {
+          "reason": "market"
+        },
+        "type": "album",
+        "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+        "album_group": "compilation",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "string"
+            },
+            "href": "string",
+            "id": "string",
+            "name": "string",
+            "type": "artist",
+            "uri": "string"
+          }
+        ]
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "string"
+          },
+          "followers": {
+            "href": "string",
+            "total": 0
+          },
+          "genres": ["Prog rock", "Grunge"],
+          "href": "string",
+          "id": "string",
+          "images": [
+            {
+              "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+              "height": 300,
+              "width": 300
+            }
+          ],
+          "name": "string",
+          "popularity": 0,
+          "type": "artist",
+          "uri": "string"
+        }
+      ],
+      "available_markets": ["string"],
+      "disc_number": 0,
+      "duration_ms": 0,
+      "explicit": true,
+      "external_ids": {
+        "isrc": "string",
+        "ean": "string",
+        "upc": "string"
+      },
+      "external_urls": {
+        "spotify": "string"
+      },
+      "href": "string",
+      "id": "string",
+      "is_playable": true,
+      "linked_from": {
+        "album": {
+          "album_type": "compilation",
+          "total_tracks": 9,
+          "available_markets": ["CA", "BR", "IT"],
+          "external_urls": {
+            "spotify": "string"
+          },
+          "href": "string",
+          "id": "2up3OPMp9Tb4dAKM2erWXQ",
+          "images": [
+            {
+              "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+              "height": 300,
+              "width": 300
+            }
+          ],
+          "name": "string",
+          "release_date": "1981-12",
+          "release_date_precision": "year",
+          "restrictions": {
+            "reason": "market"
+          },
+          "type": "album",
+          "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+          "album_group": "compilation",
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "string"
+              },
+              "href": "string",
+              "id": "string",
+              "name": "string",
+              "type": "artist",
+              "uri": "string"
+            }
+          ]
+        },
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "string"
+            },
+            "followers": {
+              "href": "string",
+              "total": 0
+            },
+            "genres": ["Prog rock", "Grunge"],
+            "href": "string",
+            "id": "string",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                "height": 300,
+                "width": 300
+              }
+            ],
+            "name": "string",
+            "popularity": 0,
+            "type": "artist",
+            "uri": "string"
+          }
+        ],
+        "available_markets": ["string"],
+        "disc_number": 0,
+        "duration_ms": 0,
+        "explicit": true,
+        "external_ids": {
+          "isrc": "string",
+          "ean": "string",
+          "upc": "string"
+        },
+        "external_urls": {
+          "spotify": "string"
+        },
+        "href": "string",
+        "id": "string",
+        "is_playable": true,
+        "linked_from": {
+          "album": {
+            "album_type": "compilation",
+            "total_tracks": 9,
+            "available_markets": ["CA", "BR", "IT"],
+            "external_urls": {
+              "spotify": "string"
+            },
+            "href": "string",
+            "id": "2up3OPMp9Tb4dAKM2erWXQ",
+            "images": [
+              {
+                "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                "height": 300,
+                "width": 300
+              }
+            ],
+            "name": "string",
+            "release_date": "1981-12",
+            "release_date_precision": "year",
+            "restrictions": {
+              "reason": "market"
+            },
+            "type": "album",
+            "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+            "album_group": "compilation",
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "string"
+                },
+                "href": "string",
+                "id": "string",
+                "name": "string",
+                "type": "artist",
+                "uri": "string"
+              }
+            ]
+          },
+          "artists": [
+            {
+              "external_urls": {
+                "spotify": "string"
+              },
+              "followers": {
+                "href": "string",
+                "total": 0
+              },
+              "genres": ["Prog rock", "Grunge"],
+              "href": "string",
+              "id": "string",
+              "images": [
+                {
+                  "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                  "height": 300,
+                  "width": 300
+                }
+              ],
+              "name": "string",
+              "popularity": 0,
+              "type": "artist",
+              "uri": "string"
+            }
+          ],
+          "available_markets": ["string"],
+          "disc_number": 0,
+          "duration_ms": 0,
+          "explicit": true,
+          "external_ids": {
+            "isrc": "string",
+            "ean": "string",
+            "upc": "string"
+          },
+          "external_urls": {
+            "spotify": "string"
+          },
+          "href": "string",
+          "id": "string",
+          "is_playable": true,
+          "linked_from": {
+            "album": {
+              "album_type": "compilation",
+              "total_tracks": 9,
+              "available_markets": ["CA", "BR", "IT"],
+              "external_urls": {
+                "spotify": "string"
+              },
+              "href": "string",
+              "id": "2up3OPMp9Tb4dAKM2erWXQ",
+              "images": [
+                {
+                  "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                  "height": 300,
+                  "width": 300
+                }
+              ],
+              "name": "string",
+              "release_date": "1981-12",
+              "release_date_precision": "year",
+              "restrictions": {
+                "reason": "market"
+              },
+              "type": "album",
+              "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+              "album_group": "compilation",
+              "artists": [
+                {
+                  "external_urls": {
+                    "spotify": "string"
+                  },
+                  "href": "string",
+                  "id": "string",
+                  "name": "string",
+                  "type": "artist",
+                  "uri": "string"
+                }
+              ]
+            },
+            "artists": [
+              {
+                "external_urls": {
+                  "spotify": "string"
+                },
+                "followers": {
+                  "href": "string",
+                  "total": 0
+                },
+                "genres": ["Prog rock", "Grunge"],
+                "href": "string",
+                "id": "string",
+                "images": [
+                  {
+                    "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                    "height": 300,
+                    "width": 300
+                  }
+                ],
+                "name": "string",
+                "popularity": 0,
+                "type": "artist",
+                "uri": "string"
+              }
+            ],
+            "available_markets": ["string"],
+            "disc_number": 0,
+            "duration_ms": 0,
+            "explicit": true,
+            "external_ids": {
+              "isrc": "string",
+              "ean": "string",
+              "upc": "string"
+            },
+            "external_urls": {
+              "spotify": "string"
+            },
+            "href": "string",
+            "id": "string",
+            "is_playable": true,
+            "linked_from": {
+              "album": {
+                "album_type": "compilation",
+                "total_tracks": 9,
+                "available_markets": ["CA", "BR", "IT"],
+                "external_urls": {
+                  "spotify": "string"
+                },
+                "href": "string",
+                "id": "2up3OPMp9Tb4dAKM2erWXQ",
+                "images": [
+                  {
+                    "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                    "height": 300,
+                    "width": 300
+                  }
+                ],
+                "name": "string",
+                "release_date": "1981-12",
+                "release_date_precision": "year",
+                "restrictions": {
+                  "reason": "market"
+                },
+                "type": "album",
+                "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+                "album_group": "compilation",
+                "artists": [
+                  {
+                    "external_urls": {
+                      "spotify": "string"
+                    },
+                    "href": "string",
+                    "id": "string",
+                    "name": "string",
+                    "type": "artist",
+                    "uri": "string"
+                  }
+                ]
+              },
+              "artists": [
+                {
+                  "external_urls": {
+                    "spotify": "string"
+                  },
+                  "followers": {
+                    "href": "string",
+                    "total": 0
+                  },
+                  "genres": ["Prog rock", "Grunge"],
+                  "href": "string",
+                  "id": "string",
+                  "images": [
+                    {
+                      "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                      "height": 300,
+                      "width": 300
+                    }
+                  ],
+                  "name": "string",
+                  "popularity": 0,
+                  "type": "artist",
+                  "uri": "string"
+                }
+              ],
+              "available_markets": ["string"],
+              "disc_number": 0,
+              "duration_ms": 0,
+              "explicit": true,
+              "external_ids": {
+                "isrc": "string",
+                "ean": "string",
+                "upc": "string"
+              },
+              "external_urls": {
+                "spotify": "string"
+              },
+              "href": "string",
+              "id": "string",
+              "is_playable": true,
+              "linked_from": {
+                "album": {
+                  "album_type": "compilation",
+                  "total_tracks": 9,
+                  "available_markets": ["CA", "BR", "IT"],
+                  "external_urls": {
+                    "spotify": "string"
+                  },
+                  "href": "string",
+                  "id": "2up3OPMp9Tb4dAKM2erWXQ",
+                  "images": [
+                    {
+                      "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                      "height": 300,
+                      "width": 300
+                    }
+                  ],
+                  "name": "string",
+                  "release_date": "1981-12",
+                  "release_date_precision": "year",
+                  "restrictions": {
+                    "reason": "market"
+                  },
+                  "type": "album",
+                  "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+                  "album_group": "compilation",
+                  "artists": [
+                    {
+                      "external_urls": {
+                        "spotify": "string"
+                      },
+                      "href": "string",
+                      "id": "string",
+                      "name": "string",
+                      "type": "artist",
+                      "uri": "string"
+                    }
+                  ]
+                },
+                "artists": [
+                  {
+                    "external_urls": {
+                      "spotify": "string"
+                    },
+                    "followers": {
+                      "href": "string",
+                      "total": 0
+                    },
+                    "genres": ["Prog rock", "Grunge"],
+                    "href": "string",
+                    "id": "string",
+                    "images": [
+                      {
+                        "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                        "height": 300,
+                        "width": 300
+                      }
+                    ],
+                    "name": "string",
+                    "popularity": 0,
+                    "type": "artist",
+                    "uri": "string"
+                  }
+                ],
+                "available_markets": ["string"],
+                "disc_number": 0,
+                "duration_ms": 0,
+                "explicit": true,
+                "external_ids": {
+                  "isrc": "string",
+                  "ean": "string",
+                  "upc": "string"
+                },
+                "external_urls": {
+                  "spotify": "string"
+                },
+                "href": "string",
+                "id": "string",
+                "is_playable": true,
+                "linked_from": {
+                  "album": {
+                    "album_type": "compilation",
+                    "total_tracks": 9,
+                    "available_markets": ["CA", "BR", "IT"],
+                    "external_urls": {
+                      "spotify": "string"
+                    },
+                    "href": "string",
+                    "id": "2up3OPMp9Tb4dAKM2erWXQ",
+                    "images": [
+                      {
+                        "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                        "height": 300,
+                        "width": 300
+                      }
+                    ],
+                    "name": "string",
+                    "release_date": "1981-12",
+                    "release_date_precision": "year",
+                    "restrictions": {
+                      "reason": "market"
+                    },
+                    "type": "album",
+                    "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+                    "album_group": "compilation",
+                    "artists": [
+                      {
+                        "external_urls": {
+                          "spotify": "string"
+                        },
+                        "href": "string",
+                        "id": "string",
+                        "name": "string",
+                        "type": "artist",
+                        "uri": "string"
+                      }
+                    ]
+                  },
+                  "artists": [
+                    {
+                      "external_urls": {
+                        "spotify": "string"
+                      },
+                      "followers": {
+                        "href": "string",
+                        "total": 0
+                      },
+                      "genres": ["Prog rock", "Grunge"],
+                      "href": "string",
+                      "id": "string",
+                      "images": [
+                        {
+                          "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                          "height": 300,
+                          "width": 300
+                        }
+                      ],
+                      "name": "string",
+                      "popularity": 0,
+                      "type": "artist",
+                      "uri": "string"
+                    }
+                  ],
+                  "available_markets": ["string"],
+                  "disc_number": 0,
+                  "duration_ms": 0,
+                  "explicit": true,
+                  "external_ids": {
+                    "isrc": "string",
+                    "ean": "string",
+                    "upc": "string"
+                  },
+                  "external_urls": {
+                    "spotify": "string"
+                  },
+                  "href": "string",
+                  "id": "string",
+                  "is_playable": true,
+                  "linked_from": {
+                    "album": {
+                      "album_type": "compilation",
+                      "total_tracks": 9,
+                      "available_markets": ["CA", "BR", "IT"],
+                      "external_urls": {
+                        "spotify": "string"
+                      },
+                      "href": "string",
+                      "id": "2up3OPMp9Tb4dAKM2erWXQ",
+                      "images": [
+                        {
+                          "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                          "height": 300,
+                          "width": 300
+                        }
+                      ],
+                      "name": "string",
+                      "release_date": "1981-12",
+                      "release_date_precision": "year",
+                      "restrictions": {
+                        "reason": "market"
+                      },
+                      "type": "album",
+                      "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+                      "album_group": "compilation",
+                      "artists": [
+                        {
+                          "external_urls": {
+                            "spotify": "string"
+                          },
+                          "href": "string",
+                          "id": "string",
+                          "name": "string",
+                          "type": "artist",
+                          "uri": "string"
+                        }
+                      ]
+                    },
+                    "artists": [
+                      {
+                        "external_urls": {
+                          "spotify": "string"
+                        },
+                        "followers": {
+                          "href": "string",
+                          "total": 0
+                        },
+                        "genres": ["Prog rock", "Grunge"],
+                        "href": "string",
+                        "id": "string",
+                        "images": [
+                          {
+                            "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                            "height": 300,
+                            "width": 300
+                          }
+                        ],
+                        "name": "string",
+                        "popularity": 0,
+                        "type": "artist",
+                        "uri": "string"
+                      }
+                    ],
+                    "available_markets": ["string"],
+                    "disc_number": 0,
+                    "duration_ms": 0,
+                    "explicit": true,
+                    "external_ids": {
+                      "isrc": "string",
+                      "ean": "string",
+                      "upc": "string"
+                    },
+                    "external_urls": {
+                      "spotify": "string"
+                    },
+                    "href": "string",
+                    "id": "string",
+                    "is_playable": true,
+                    "linked_from": {
+                      "album": {
+                        "album_type": "compilation",
+                        "total_tracks": 9,
+                        "available_markets": ["CA", "BR", "IT"],
+                        "external_urls": {
+                          "spotify": "string"
+                        },
+                        "href": "string",
+                        "id": "2up3OPMp9Tb4dAKM2erWXQ",
+                        "images": [
+                          {
+                            "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+                            "height": 300,
+                            "width": 300
+                          }
+                        ],
+                        "name": "string",
+                        "release_date": "1981-12",
+                        "release_date_precision": "year",
+                        "restrictions": {
+                          "reason": "market"
+                        },
+                        "type": "album",
+                        "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+                        "album_group": "compilation",
+                        "artists": [
+                          {
+                            "external_urls": {},
+                            "href": "string",
+                            "id": "string",
+                            "name": "string",
+                            "type": "artist",
+                            "uri": "string"
+                          }
+                        ]
+                      },
+                      "artists": [
+                        {
+                          "external_urls": {
+                            "spotify": "string"
+                          },
+                          "followers": {
+                            "href": "string",
+                            "total": 0
+                          },
+                          "genres": ["Prog rock", "Grunge"],
+                          "href": "string",
+                          "id": "string",
+                          "images": [{}],
+                          "name": "string",
+                          "popularity": 0,
+                          "type": "artist",
+                          "uri": "string"
+                        }
+                      ],
+                      "available_markets": ["string"],
+                      "disc_number": 0,
+                      "duration_ms": 0,
+                      "explicit": true,
+                      "external_ids": {
+                        "isrc": "string",
+                        "ean": "string",
+                        "upc": "string"
+                      },
+                      "external_urls": {
+                        "spotify": "string"
+                      },
+                      "href": "string",
+                      "id": "string",
+                      "is_playable": true,
+                      "linked_from": {
+                        "album": {
+                          "album_type": "compilation",
+                          "total_tracks": 9,
+                          "available_markets": ["CA", "BR", "IT"],
+                          "external_urls": {
+                            "spotify": "string"
+                          },
+                          "href": "string",
+                          "id": "2up3OPMp9Tb4dAKM2erWXQ",
+                          "images": [{}],
+                          "name": "string",
+                          "release_date": "1981-12",
+                          "release_date_precision": "year",
+                          "restrictions": {
+                            "reason": "market"
+                          },
+                          "type": "album",
+                          "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+                          "album_group": "compilation",
+                          "artists": [{}]
+                        },
+                        "artists": [
+                          {
+                            "external_urls": {},
+                            "followers": {},
+                            "genres": ["Prog rock", "Grunge"],
+                            "href": "string",
+                            "id": "string",
+                            "images": [{}],
+                            "name": "string",
+                            "popularity": 0,
+                            "type": "artist",
+                            "uri": "string"
+                          }
+                        ],
+                        "available_markets": ["string"],
+                        "disc_number": 0,
+                        "duration_ms": 0,
+                        "explicit": true,
+                        "external_ids": {
+                          "isrc": "string",
+                          "ean": "string",
+                          "upc": "string"
+                        },
+                        "external_urls": {
+                          "spotify": "string"
+                        },
+                        "href": "string",
+                        "id": "string",
+                        "is_playable": true,
+                        "linked_from": {
+                          "album": {
+                            "album_type": "compilation",
+                            "total_tracks": 9,
+                            "available_markets": ["CA", "BR", "IT"],
+                            "external_urls": {},
+                            "href": "string",
+                            "id": "2up3OPMp9Tb4dAKM2erWXQ",
+                            "images": [{}],
+                            "name": "string",
+                            "release_date": "1981-12",
+                            "release_date_precision": "year",
+                            "restrictions": {},
+                            "type": "album",
+                            "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+                            "album_group": "compilation",
+                            "artists": [{}]
+                          },
+                          "artists": [
+                            {
+                              "genres": [],
+                              "images": []
+                            }
+                          ],
+                          "available_markets": ["string"],
+                          "disc_number": 0,
+                          "duration_ms": 0,
+                          "explicit": true,
+                          "external_ids": {
+                            "isrc": "string",
+                            "ean": "string",
+                            "upc": "string"
+                          },
+                          "external_urls": {
+                            "spotify": "string"
+                          },
+                          "href": "string",
+                          "id": "string",
+                          "is_playable": true,
+                          "linked_from": {
+                            "album": {
+                              "available_markets": [],
+                              "images": [],
+                              "artists": []
+                            },
+                            "artists": [{}],
+                            "available_markets": [null],
+                            "disc_number": 0,
+                            "duration_ms": 0,
+                            "explicit": true,
+                            "external_ids": {},
+                            "external_urls": {},
+                            "href": "string",
+                            "id": "string",
+                            "is_playable": true,
+                            "linked_from": {
+                              "artists": [],
+                              "available_markets": []
+                            },
+                            "restrictions": {},
+                            "name": "string",
+                            "popularity": 0,
+                            "preview_url": "string",
+                            "track_number": 0,
+                            "type": "string",
+                            "uri": "string",
+                            "is_local": true
+                          },
+                          "restrictions": {
+                            "reason": "string"
+                          },
+                          "name": "string",
+                          "popularity": 0,
+                          "preview_url": "string",
+                          "track_number": 0,
+                          "type": "string",
+                          "uri": "string",
+                          "is_local": true
+                        },
+                        "restrictions": {
+                          "reason": "string"
+                        },
+                        "name": "string",
+                        "popularity": 0,
+                        "preview_url": "string",
+                        "track_number": 0,
+                        "type": "string",
+                        "uri": "string",
+                        "is_local": true
+                      },
+                      "restrictions": {
+                        "reason": "string"
+                      },
+                      "name": "string",
+                      "popularity": 0,
+                      "preview_url": "string",
+                      "track_number": 0,
+                      "type": "string",
+                      "uri": "string",
+                      "is_local": true
+                    },
+                    "restrictions": {
+                      "reason": "string"
+                    },
+                    "name": "string",
+                    "popularity": 0,
+                    "preview_url": "string",
+                    "track_number": 0,
+                    "type": "string",
+                    "uri": "string",
+                    "is_local": true
+                  },
+                  "restrictions": {
+                    "reason": "string"
+                  },
+                  "name": "string",
+                  "popularity": 0,
+                  "preview_url": "string",
+                  "track_number": 0,
+                  "type": "string",
+                  "uri": "string",
+                  "is_local": true
+                },
+                "restrictions": {
+                  "reason": "string"
+                },
+                "name": "string",
+                "popularity": 0,
+                "preview_url": "string",
+                "track_number": 0,
+                "type": "string",
+                "uri": "string",
+                "is_local": true
+              },
+              "restrictions": {
+                "reason": "string"
+              },
+              "name": "string",
+              "popularity": 0,
+              "preview_url": "string",
+              "track_number": 0,
+              "type": "string",
+              "uri": "string",
+              "is_local": true
+            },
+            "restrictions": {
+              "reason": "string"
+            },
+            "name": "string",
+            "popularity": 0,
+            "preview_url": "string",
+            "track_number": 0,
+            "type": "string",
+            "uri": "string",
+            "is_local": true
+          },
+          "restrictions": {
+            "reason": "string"
+          },
+          "name": "string",
+          "popularity": 0,
+          "preview_url": "string",
+          "track_number": 0,
+          "type": "string",
+          "uri": "string",
+          "is_local": true
+        },
+        "restrictions": {
+          "reason": "string"
+        },
+        "name": "string",
+        "popularity": 0,
+        "preview_url": "string",
+        "track_number": 0,
+        "type": "string",
+        "uri": "string",
+        "is_local": true
+      },
+      "restrictions": {
+        "reason": "string"
+      },
+      "name": "string",
+      "popularity": 0,
+      "preview_url": "string",
+      "track_number": 0,
+      "type": "string",
+      "uri": "string",
+      "is_local": true
+    }
+  ]
+}

--- a/__test__/spotify-web-api.spec.js
+++ b/__test__/spotify-web-api.spec.js
@@ -1667,6 +1667,24 @@ describe('Basic tests', function () {
       );
     });
 
+    it("should get the user's queue", function () {
+      var callback = sinon.spy();
+      var api = new SpotifyWebApi();
+      api.getMyQueue(callback);
+      that.requests[0].respond(
+        200,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(fixtures.get_queue)
+      );
+
+      expect(that.requests[0].method).toBe('GET');
+      expect(callback.calledWith(null, fixtures.get_queue)).toBeTruthy();
+      expect(that.requests.length).toBe(1);
+      expect(that.requests[0].url).toBe(
+        'https://api.spotify.com/v1/me/player/queue'
+      );
+    });
+
     it('should transfer playback', function () {
       var callback = sinon.spy();
       var api = new SpotifyWebApi();

--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -1592,6 +1592,23 @@ var SpotifyWebApi = (function () {
   };
 
   /**
+   * Get the list of objects that make up the user's queue.
+   * See [Get the User's Queue](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-queue) on
+   * the Spotify Developer site for more information about the endpoint.
+   *
+   * @param {Object} options A JSON object with options that can be passed.
+   * @param {function(Object,Object)} callback An optional callback that receives 2 parameters. The first
+   * one is the error object (null if no error), and the second is the value if the request succeeded.
+   * @returns {Object} Null if a callback is provided, a `Promise` object otherwise
+   */
+  Constr.prototype.getMyQueue = function (options, callback) {
+    var requestData = {
+      url: _baseUri + '/me/player/queue'
+    };
+    return _checkParamsAndPerformRequest(requestData, options, callback);
+  };
+
+  /**
    * Transfer playback to a new device and determine if it should start playing.
    * See [Transfer a User’s Playback](https://developer.spotify.com/web-api/transfer-a-users-playback/) on
    * the Spotify Developer site for more information about the endpoint.

--- a/src/typings/spotify-api.d.ts
+++ b/src/typings/spotify-api.d.ts
@@ -735,6 +735,8 @@ declare namespace SpotifyApi {
 
   interface CurrentlyPlayingResponse extends CurrentlyPlayingObject {}
 
+  interface QueueResponse extends QueueObject {}
+
   /**
    * Get a list of a user's saved shows
    *
@@ -1163,6 +1165,11 @@ declare namespace SpotifyApi {
     context: ContextObject | null;
   }
 
+  interface QueueObject {
+    currently_playing: TrackObjectFull
+    queue: TrackObjectFull[]
+  }
+
   interface UserDevice {
     id: string | null;
     is_active: boolean;
@@ -1246,3 +1253,5 @@ declare namespace SpotifyApi {
   type ContextObjectType = 'artist' | 'playlist' | 'album';
   type PlaybackRepeatState = 'off' | 'track' | 'context';
 }
+
+

--- a/src/typings/spotify-web-api.d.ts
+++ b/src/typings/spotify-web-api.d.ts
@@ -1367,6 +1367,27 @@ declare namespace SpotifyWebApi {
     getMyCurrentPlayingTrack(
       callback: ResultsCallback<SpotifyApi.CurrentlyPlayingResponse>
     ): void;
+    
+    /**
+     * Get the list of objects that make up the user's queue.
+     * See [Get the User's Queue](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-queue) on
+     * the Spotify Developer site for more information about the endpoint.
+     * 
+     * @param {Object} options A JSON object with options that can be passed.
+     * @param {function(Object,Object)} callback An optional callback that receives 2 parameters. The first
+     * one is the error object (null if no error), and the second is the value if the request succeeded.
+     * @returns {Object} Null if a callback is provided, a `Promise` object otherwise
+     */
+    getMyQueue(
+      options?: Object
+    ): Promise<SpotifyApi.QueueResponse>
+    getMyQueue(
+      options: Object,
+      callback: ResultsCallback<SpotifyApi.QueueResponse>
+    ): void
+    getMyQueue(
+      callback: ResultsCallback<SpotifyApi.QueueResponse>
+    ): void
 
     /**
      * Transfer playback to a new device and determine if it should start playing.


### PR DESCRIPTION
[endpoint documentation](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-queue)

Added support for "Get the User's Queue" API endpoint.
Not 100% about which type to use for `options`, as the endpoint dosen't have any query parameters
