### PR TITLE
Update spotify-api.d.ts PagingObject

### DIFF
--- a/src/typings/spotify-api.d.ts
+++ b/src/typings/spotify-api.d.ts
@@ -940,9 +940,9 @@ declare namespace SpotifyApi {
     href: string;
     items: T[];
     limit: number;
-    next: string;
+    next: string | null;
     offset: number;
-    previous: string;
+    previous: string  | null;
     total: number;
   }
 


### PR DESCRIPTION
next and previous are both nullable string, according to the api.